### PR TITLE
Count elapsed time in microseconds

### DIFF
--- a/examples/AltitudeEstimation/AltitudeEstimation.ino
+++ b/examples/AltitudeEstimation/AltitudeEstimation.ino
@@ -185,7 +185,7 @@ void loop(void)
   float pressure;
   barometer.getPressure(& pressure);
   float baroHeight = getAltitude(pressure);
-  float timestamp = millis();
+  uint32_t timestamp = micros();
   float accelData[3];
   float gyroData[3];
   getGyrometerAndAccelerometer(gyroData, accelData);

--- a/src/altitude.hpp
+++ b/src/altitude.hpp
@@ -22,7 +22,7 @@ class AltitudeEstimator {
     // gravity
     float g = 9.81;
     // For computing the sampling period
-    float previousTime = millis();
+    uint32_t previousTime = micros();
     // required filters for altitude and vertical velocity estimation
     KalmanFilter kalman;
     ComplementaryFilter complementary;
@@ -50,18 +50,18 @@ class AltitudeEstimator {
 
     }
 
-    void estimate(float accel[3], float gyro[3], float baroHeight, float timestamp)
+    void estimate(float accel[3], float gyro[3], float baroHeight, uint32_t timestamp)
     {
         float verticalAccel = kalman.estimate(pastGyro,
                                               pastAccel,
-                                              (timestamp-previousTime)/1000.0);
+                                              (timestamp-previousTime)/1000000.0);
         complementary.estimate(& estimatedVelocity,
                                & estimatedAltitude,
                                baroHeight,
                                pastAltitude,
                                pastVerticalVelocity,
                                pastVerticalAccel,
-                               (timestamp-previousTime)/1000.0);
+                               (timestamp-previousTime)/1000000.0);
         // update values for next iteration
         copyVector(pastGyro, gyro);
         copyVector(pastAccel, accel);


### PR DESCRIPTION
## Issue/Feature this PR addresses

#6 

## Expected behavior after merging 
The elapsed time between two consecutive sensor readings is measured in microseconds instead of milliseconds. Also, use `uint32_t` instead of `float` to store the measured times.