### PR TITLE
Reduce the number of iterations used to calibrate the baro

### DIFF
--- a/examples/AltitudeEstimation/AltitudeEstimation.ino
+++ b/examples/AltitudeEstimation/AltitudeEstimation.ino
@@ -20,7 +20,7 @@ float   groundPressure = 0;
 float   pressureSum = 0;
 float   history[HISTORY_SIZE];
 uint8_t historyIdx = 0;
-int     endCalibration = 150;
+int     endCalibration = 70;
 
 MS5637 barometer = MS5637();
 
@@ -185,7 +185,7 @@ void loop(void)
   float pressure;
   barometer.getPressure(& pressure);
   float baroHeight = getAltitude(pressure);
-  uint32_t timestamp = micros();
+  float timestamp = millis();
   float accelData[3];
   float gyroData[3];
   getGyrometerAndAccelerometer(gyroData, accelData);


### PR DESCRIPTION
# Issue/Feature this PR addresses

Baro calibration time is too long

# Expected behavior after merge

Baro calibration time is reduced by half. Note that at least 48 iterations are required to fill the history array of baro readings. To be safe and discard the first readings which can be innaccurate we set the number of iterations to 70. Before it was 150.